### PR TITLE
Fix duplicated form1 at case.json

### DIFF
--- a/casecentral/case_central/doctype/case/case.json
+++ b/casecentral/case_central/doctype/case/case.json
@@ -382,16 +382,6 @@
    "label": "Pleadings / Issues"
   },
   {
-   "fieldname": "form_1_tab",
-   "fieldtype": "Tab Break",
-   "label": "Form 1"
-  },
-  {
-   "fieldname": "pleadings__issues_section",
-   "fieldtype": "Section Break",
-   "label": "Pleadings / Issues"
-  },
-  {
    "fieldname": "tab_3_tab",
    "fieldtype": "Tab Break",
    "label": "Form 2"


### PR DESCRIPTION
Just reviewing the code, and formatting / translating to Brazilian Portuguese, and figured out that there are two Form1 sections.